### PR TITLE
ci: modernize workflow and add multi-platform support

### DIFF
--- a/.devops/install_dependencies.sh
+++ b/.devops/install_dependencies.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+PLATFORM=$1
+BUILD_TYPE=$2
+SFML_VERSION="2.6.x"
+JSONBOX_REPO="https://github.com/cristianglezm/JsonBox"
+SFML_REPO="https://github.com/SFML/SFML"
+
+case "$PLATFORM" in
+    Linux*)
+        echo ">> Building dependencies for Linux..."
+        if [ ! -d "JsonBox" ]; then git clone $JSONBOX_REPO; fi
+        cd JsonBox && mkdir -p build && cd build
+        export JsonBox_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$JsonBox_ROOT -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS=-fPIC ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+
+        if [ ! -d "SFML" ]; then git clone $SFML_REPO; fi
+        cd SFML && git checkout $SFML_VERSION && mkdir -p build && cd build
+        export SFML_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$SFML_ROOT -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSFML_BUILD_AUDIO=ON -DSFML_BUILD_GRAPHICS=ON ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+    ;;
+
+    mac*)
+        echo ">> Building dependencies for macOS..."
+        if [ ! -d "JsonBox" ]; then git clone $JSONBOX_REPO; fi
+        cd JsonBox && mkdir -p build && cd build
+        export JsonBox_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$JsonBox_ROOT -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="-fPIC" ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+
+        if [ ! -d "SFML" ]; then git clone $SFML_REPO; fi
+        cd SFML && git checkout $SFML_VERSION && mkdir -p build && cd build
+        export SFML_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$SFML_ROOT -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSFML_BUILD_AUDIO=ON -DSFML_BUILD_GRAPHICS=ON ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+    ;;
+
+    "Windows MinGW"*)
+        echo ">> Building dependencies for Windows (MinGW)..."
+        if [ ! -d "JsonBox" ]; then git clone $JSONBOX_REPO; fi
+        cd JsonBox && mkdir -p build && cd build
+        export JsonBox_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$JsonBox_ROOT -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+
+        if [ ! -d "SFML" ]; then git clone $SFML_REPO; fi
+        cd SFML && git checkout $SFML_VERSION && mkdir -p build && cd build
+        export SFML_ROOT=$(pwd)/install
+        cmake -DCMAKE_INSTALL_PREFIX=$SFML_ROOT \
+              -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+              -DCMAKE_C_COMPILER=gcc \
+              -DCMAKE_CXX_COMPILER=g++ \
+              -DSFML_BUILD_AUDIO=ON \
+              -DSFML_BUILD_GRAPHICS=ON \
+              -GNinja ..
+        cmake --build . -j 4 --target install --config $BUILD_TYPE
+        cd ../..
+    ;;
+
+    Android*)
+        echo ">> Building dependencies for Android..."
+        export ANDROID_NDK=$ANDROID_SDK_ROOT/ndk/26.2.11394342
+        export ANDROID_SOURCES=$ANDROID_NDK/sources/third_party
+        export ARCH_ABIS="armeabi-v7a arm64-v8a x86 x86_64"
+        export JsonBox_ROOT=$ANDROID_SOURCES/JsonBox
+        if [ ! -d "JsonBox" ]; then git clone $JSONBOX_REPO; fi
+        cd JsonBox && mkdir -p build && cd build
+        for arch in $ARCH_ABIS;do
+            cmake --fresh -DCMAKE_INSTALL_PREFIX=$JsonBox_ROOT \
+                            -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+                            -DCMAKE_SYSTEM_NAME=Android \
+                            -DCMAKE_ANDROID_NDK=$ANDROID_NDK \
+                            -DCMAKE_ANDROID_ARCH_ABI="$arch" \
+                            -DCMAKE_ANDROID_STL_TYPE=c++_shared \
+                            -DCMAKE_ANDROID_API=33 \
+                            -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang \
+                            -DBUILD_SHARED_LIBS=TRUE \
+                            -DCMAKE_CXX_FLAGS=-fPIC ..
+            cmake --build . -j 4 --target install --config $BUILD_TYPE
+        done
+        cd ../..
+
+        export SFML_ANDROID_ROOT=${ANDROID_SOURCES}/SFML
+        if [ ! -d "SFML" ]; then git clone $SFML_REPO; fi
+        cd SFML && git checkout $SFML_VERSION && mkdir -p build && cd build
+        for arch in $ARCH_ABIS;do
+             rm -rf * 
+             cmake -DCMAKE_INSTALL_PREFIX=${SFML_ANDROID_ROOT} \
+                   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+                   -DCMAKE_SYSTEM_NAME=Android \
+                   -DCMAKE_ANDROID_NDK=$ANDROID_NDK \
+                   -DCMAKE_ANDROID_ARCH_ABI=${arch} \
+                   -DCMAKE_ANDROID_STL_TYPE=c++_shared \
+                   -DCMAKE_ANDROID_API=33 \
+                   -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang \
+                   ..
+             cmake --build . -j 4 --target install --config $BUILD_TYPE
+        done
+        cd ../..
+    ;;
+
+    *)
+      echo "Platform '$PLATFORM' not supported in dependency script yet."
+      echo "usage:"
+      echo "$0 <platform> <build_type>"
+      echo "where platforms:"
+      echo "    Linux"
+      echo "    Windows MinGW"
+      echo "    Mac"
+      echo "    Android"
+      echo "and build_types:"
+      echo "    Release"
+      echo "    Debug"
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,102 +1,124 @@
 name: ci
-on: push
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
-    name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
+    name: ${{ matrix.platform.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
       fail-fast: false
       matrix:
         platform:
-        - { name: LinuxGCC, os: ubuntu-latest, prefix: xvfb-run -a }
-        - { name: Android,  os: ubuntu-latest }
-        config:
-        - { name: Shared, flags: -DAntFarm_BUILD_STATIC=FALSE }
-        #- { name: Static, flags: -DAntFarm_BUILD_STATIC=TRUE }
+        - { name: "Windows MinGW", os: windows-2022, flags: -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: "Linux GCC",     os: ubuntu-22.04, flags: -G"Unix Makefiles" }
+        - { name: "macOS ARM64",   os: macos-14,     flags: -GNinja }
         type:
-        - { name: Release }
-        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DJSONBOX_LIBRARY=/home/runner/work/AntFarm/AntFarm/JsonBox/build/install/lib/libJsonBox_d.a }
-        include:
-        - platform: { name: LinuxGCC, os: ubuntu-latest }
-          config: { name: Shared, flags: -DAntFarm_BUILD_STATIC=FALSE }
-    steps:
-    - name: checkout code
-      uses: actions/checkout@v4
+        - { name: Release, flags: -DCMAKE_BUILD_TYPE=Release }
+        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
 
-    - name: cache linux
+        include:
+        - platform: { name: Android, os: ubuntu-22.04 }
+          type: { name: Release }
+        - platform: { name: Android, os: ubuntu-22.04 }
+          type: { name: Debug }
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v5
+
+    - name: Set up MSYS2
+      if: matrix.platform.name == 'Windows MinGW'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          git
+          base-devel
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-ninja
+
+    - name: Get CMake and Ninja
+      if: matrix.platform.name != 'Windows MinGW'
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: '3.28'
+        ninjaVersion: latest
+
+    - name: Install Linux Dependencies
       if: runner.os == 'Linux' && matrix.platform.name != 'Android'
-      id: cache-linux
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb
+
+    - name: Cache Deps (Desktop)
+      if: matrix.platform.name != 'Android'
+      id: cache-deps
       uses: actions/cache@v4
       with:
         path: |
-          SFML/build/install
-          JsonBox/build/install
-        key: ${{ matrix.platform.name }}-${{ matrix.type.name }}-${{ matrix.config.name }}
+          $GITHUB_WORKSPACE/JsonBox/build/install
+          $GITHUB_WORKSPACE/SFML/build/install
+        key: ${{ matrix.platform.name }}-${{ matrix.type.name }}-sfml2.6
 
-    - name: install linux dependencies
-      if: runner.os == 'Linux' && matrix.platform.name != 'Android'
-      run: sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
-
-    - name: build sfml and jsonbox
-      if: runner.os == 'Linux' && matrix.platform.name != 'Android' && steps.cache-linux.outputs.cache-hit != 'true'
-      run: |
-        git clone https://github.com/SFML/SFML && cd SFML && git checkout 2.6.x
-        export SFML_ROOT=$(pwd)/build/install
-        mkdir build && cd build
-        cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=${{ matrix.type.name }} .. && make -j4 install && cd ../..
-        git clone https://github.com/cristianglezm/JsonBox && cd JsonBox && mkdir build && cd build
-        export JSONBOX_ROOT=$(pwd)/install
-        cmake -DCMAKE_INSTALL_PREFIX=$JSONBOX_ROOT -DCMAKE_BUILD_TYPE=${{ matrix.type.name }} .. && make -j 4 install && cd ../..
-
-    - name: configure and build AntFarm
-      if: matrix.platform.name == 'LinuxGCC'
-      shell: bash
-      run: |
-        cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DSFML_ROOT=$GITHUB_WORKSPACE/SFML/build/install -DJSONBOX_ROOT=$GITHUB_WORKSPACE/JsonBox/build/install ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
-        ${{ matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
-
-    - name: cache android
+    - name: Cache Android NDK
       if: matrix.platform.name == 'Android'
       id: cache-android
       uses: actions/cache@v4
       with:
-         path: /usr/local/lib/android/sdk/ndk/26.2.11394342
-         key: ${{ matrix.platform.name }}-${{ matrix.type.name }}-${{ matrix.config.name }}
+        path: ${{ env.ANDROID_SDK_ROOT }}/ndk/26.2.11394342
+        key: android-ndk-26.2.11394342
 
-    - name: install android dependencies
+    - name: Install Android Components
       if: matrix.platform.name == 'Android' && steps.cache-android.outputs.cache-hit != 'true'
       run: |
-         echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;26.2.11394342"
-         export ANDROID_SDK=${ANDROID_SDK_ROOT}
-         export ANDROID_NDK=${ANDROID_SDK}/ndk/26.2.11394342
-         export ANDROID_FLAGS="-DCMAKE_BUILD_TYPE=${{ matrix.type.name }} -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=33"
-         export ARCH_ABIS="armeabi-v7a arm64-v8a x86 x86_64"
-         git clone https://github.com/SFML/SFML && cd SFML && git checkout 2.6.x && mkdir build && cd build
-         export SFML_ANDROID_ROOT=${ANDROID_NDK}/sources/third_party/SFML
-         for arch in $ARCH_ABIS;do
-             cmake ${ANDROID_FLAGS} -DCMAKE_ANDROID_ARCH_ABI=${arch} -DCMAKE_INSTALL_PREFIX=${SFML_ANDROID_ROOT} ..
-             make -j4 install
-             rm -R *
-         done
-         cd ../..
-         git clone https://github.com/cristianglezm/JsonBox && cd JsonBox && mkdir build && cd build
-         export JsonBox_ANDROID_ROOT=$ANDROID_NDK/sources/third_party/JsonBox
-         for arch in $ARCH_ABIS;do
-             cmake $ANDROID_FLAGS -DCMAKE_ANDROID_ARCH_ABI=${arch} -DCMAKE_INSTALL_PREFIX=${JsonBox_ANDROID_ROOT} -DBUILD_SHARED_LIBS=TRUE ..
-             make -j4 install
-             rm -R *
-         done
-         cd ../..
-    - name: setup-java
+        echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "build-tools;33.0.2"
+        echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;26.2.11394342"
+
+    - name: Build Dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        chmod +x .devops/install_dependencies.sh
+        bash .devops/install_dependencies.sh "${{ matrix.platform.name }}" ${{ matrix.type.name }}
+
+    - name: Configure and Build (Desktop)
+      if: matrix.platform.name != 'Android'
+      run: |
+        export SFML_ROOT=$GITHUB_WORKSPACE/SFML/build/install
+        export JSONBOX_ROOT=$GITHUB_WORKSPACE/JsonBox/build/install
+        mkdir build && cd build
+        cmake ${{ matrix.platform.flags }} ${{ matrix.type.flags }} \
+              -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install \
+              -DSFML_ROOT=$SFML_ROOT \
+              -DJSONBOX_ROOT=$JSONBOX_ROOT \
+              -DAntFarm_WITH_GUI=TRUE \
+              -DAntFarm_BUILD_TESTS=FALSE \
+              ..
+        cmake --build . --config ${{ matrix.type.name }} -j 4 --target install
+
+    - name: Setup Java
       if: matrix.platform.name == 'Android'
       uses: actions/setup-java@v4
       with:
         distribution: 'oracle'
         java-version: '18'
 
-    - name: build apk
+    - name: Build Android APK
       if: matrix.platform.name == 'Android'
       run: |
         export ANDROID_SDK=${ANDROID_SDK_ROOT}
@@ -105,10 +127,64 @@ jobs:
         export NDK_MODULE_PATH=${ANDROID_NDK}/sources/
         ./gradlew assemble${{ matrix.type.name }} --parallel
 
-    - name: upload apk debug
+    - name: Package Windows Release
+      if: matrix.platform.name == 'Windows MinGW' && matrix.type.name == 'Release'
+      run: |
+        cp $GITHUB_WORKSPACE/SFML/build/install/bin/*.dll install/bin/ || true
+        cp $GITHUB_WORKSPACE/SFML/build/install/bin/openal32.dll install/bin/ || true
+        cp $GITHUB_WORKSPACE/SFML/build/install/share/doc/SFML/license.md install/SFML-license.md || true
+        cp $GITHUB_WORKSPACE/JsonBox/license.txt install/JsonBox-license.md || true
+        cp $(dirname $(which gcc))/libstdc++-6.dll install/bin/ || true
+        cp $(dirname $(which gcc))/libgcc_s_*.dll install/bin/ || true
+        cp $(dirname $(which gcc))/libwinpthread-1.dll install/bin/ || true
+        cd install
+        7z a ../AntFarm-Windows-Release.zip .
+
+    - name: Upload Windows Release
+      if: matrix.platform.name == 'Windows MinGW' && matrix.type.name == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: AntFarm-Windows-Release
+        path: AntFarm-Windows-Release.zip
+
+    - name: Package Linux Release
+      if: matrix.platform.name == 'Linux GCC' && matrix.type.name == 'Release'
+      run: |
+        cd install
+        cp $GITHUB_WORKSPACE/SFML/build/install/license.md SFML-license.md || true
+        cp $GITHUB_WORKSPACE/JsonBox/license.txt JsonBox-license.md || true
+        tar -czvf ../AntFarm-Linux-Release.tar.gz .
+
+    - name: Upload Linux Release
+      if: matrix.platform.name == 'Linux GCC' && matrix.type.name == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: AntFarm-Linux-Release
+        path: AntFarm-Linux-Release.tar.gz
+
+    - name: Package macOS Release
+      if: contains(matrix.platform.name, 'macOS') && matrix.type.name == 'Release'
+      run: |
+        cd install
+        tar -czvf ../AntFarm-macOS-Release.tar.gz .
+
+    - name: Upload macOS Release
+      if: contains(matrix.platform.name, 'macOS') && matrix.type.name == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: AntFarm-macOS-Release
+        path: AntFarm-macOS-Release.tar.gz
+
+    - name: Upload Android Debug
       if: matrix.platform.name == 'Android' && matrix.type.name == 'Debug'
       uses: actions/upload-artifact@v4
       with:
-        name: Antfarm-android-debug-apk
+        name: AntFarm-Android-Debug
         path: android/app/build/outputs/apk/debug/app-debug.apk
 
+    - name: Upload Android Unsigned Release
+      if: matrix.platform.name == 'Android' && matrix.type.name == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: AntFarm-Android-Release
+        path: android/app/build/outputs/apk/release/app-release-unsigned.apk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.1...3.21)
-
 #cmake_policy(SET CMP0074 NEW)
 
 ################################################################################
@@ -46,14 +45,21 @@ FILE(GLOB_RECURSE AntFarm_SOURCES "src/*.cpp" "src/*")
 FILE(GLOB_RECURSE AntFarm_INCLUDES "include/*.h" "include/*.hpp")
 
 if(WIN32)
+    message(STATUS "Looking for SFML DLLs in: ${SFML_ROOT}/bin")
 	FILE(GLOB_RECURSE SFML_DEBUG_DLLS "${SFML_ROOT}/bin/sfml-*-d-2.dll")
 	FILE(GLOB_RECURSE SFML_RELEASE_DLLS "${SFML_ROOT}/bin/*-2.dll")
+    FILE(GLOB_RECURSE OPENAL_DLL "${SFML_ROOT}/bin/openal32.dll")
+
 	if(NOT SFML_DEBUG_DLLS STREQUAL "")
 		LIST(REMOVE_ITEM SFML_RELEASE_DLLS ${SFML_DEBUG_DLLS})
 	endif()
 endif(WIN32)
 
-add_executable(AntFarm ${AntFarm_SOURCES} ${AntFarm_INCLUDES})
+if(APPLE)
+    add_executable(AntFarm MACOSX_BUNDLE ${AntFarm_SOURCES} ${AntFarm_INCLUDES})
+else()
+    add_executable(AntFarm ${AntFarm_SOURCES} ${AntFarm_INCLUDES})
+endif()
 
 ################################################################################
 ### Testing
@@ -84,13 +90,12 @@ if(JSONBOX_FOUND)
 endif(JSONBOX_FOUND)
 
 ################################################################################
-### Enable C++17 and warnings
+### Compiler Flags
 ################################################################################
 
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
-
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++17")
 
 if(WIN32)
@@ -102,7 +107,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -pg")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -g")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fexpensive-optimizations")
 endif()
@@ -139,16 +144,20 @@ endif(AntFarm_BUILD_DOCS)
 ### Installing Game
 #################################################################################
 
-install(TARGETS AntFarm RUNTIME DESTINATION .
-			ARCHIVE DESTINATION .)
+install(TARGETS AntFarm
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION .
+        ARCHIVE DESTINATION .
+)
+
 install(FILES LICENSE.md README.md DESTINATION .)
 
 if(NOT AntFarm_BUILD_STATIC AND WIN32)
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-		install(FILES ${SFML_DEBUG_DLLS} DESTINATION .)
+		install(FILES ${SFML_DEBUG_DLLS} ${OPENAL_DLL} DESTINATION .)
 	elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-		install(FILES ${SFML_RELEASE_DLLS} DESTINATION .)
+		install(FILES ${SFML_RELEASE_DLLS} ${OPENAL_DLL} DESTINATION .)
 	endif()
-endif(NOT AntFarm_BUILD_STATIC AND WIN32)
+endif()
 
 install(DIRECTORY android/app/src/main/assets/data DESTINATION .)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2014-2024 Cristian Glez <Cristian.glez.m@gmail.com>
+Copyright 2014-2025 Cristian Gonzalez <Cristian.glez.m@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # AntFarm
 
-|Linux \| windows(MinGW) | ![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)|
-|---|---|
-|Android |![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)|
+| Platform | Architecture | CI Status |
+| :--- | :--- | :--- |
+| **Linux** (Ubuntu 22.04) | x64 | [![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml) |
+| **Windows** (MinGW) | x64 | [![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml) |
+| **macOS** | ARM64 (M1/M2) | [![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml) |
+| **Android** (API 33) | x86, armv7, arm64 | [![Build Status](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml/badge.svg)](https://github.com/cristianglezm/antfarm/actions/workflows/ci.yml) |
 
 AntFarm is a game about ants that are trapped and they have to escape.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,12 @@
 TODO
 ===
 
-* modernize
-    - CMake
-    - Android
-* refactor AssetManager, SpawnSystem
-* add options, optionsState
+* [ ] modernize
+    - [ ] CMake
+    - [ ] Android
+* [ ] migrate to sfml 3
+* [ ] refactor AssetManager, SpawnSystem
+* [ ] add options, optionsState
     - resolution, music, scale for (ants, doors)
 * Add Features...
 


### PR DESCRIPTION
- **Workflows:** Overhauled `ci.yml` to support Windows (MinGW), Linux, macOS (ARM64), and Android via a matrix strategy.
- **Dependencies:** Added `.devops/install_dependencies.sh` to compile SFML and JsonBox from source for all targets, ensuring ABI compatibility.
- **Artifacts:** Configured automatic packaging and uploading of Release builds (Zip/Tarball/APK) for all platforms.
- **Windows:** Added logic to bundle necessary MinGW and SFML DLLs for standalone execution.
- **macOS:** Updated `CMakeLists.txt` to generate a `.app` bundle.
- **Misc:** Updated License copyright to 2025 and refreshed project TODOs.